### PR TITLE
Added missing library flags to example target `logo`.

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -25,7 +25,9 @@ LDADD = \
 
 AM_LDFLAGS = \
 	$(GTK_LIBS)		\
-	$(GDKGLEXT_WIN_LIBS)
+	$(GDKGLEXT_WIN_LIBS) \
+	$(MATH_LIB) \
+	$(GL_LIBS)
 
 if GLU
 noinst_LTLIBRARIES = libdrawshapes.la


### PR DESCRIPTION
At least on Ubuntu 14.04 the gtkglext example `logo` was not compiling because
of missing OpenGL and math library flags. Added them to Makefile.am.
