### PR TITLE
windows.h needs to be included before gl.h

### DIFF
--- a/gtk/gtkglwidget.c
+++ b/gtk/gtkglwidget.c
@@ -23,6 +23,11 @@
 #include "gtkglprivate.h"
 #include "gtkglwidget.h"
 
+#ifdef G_OS_WIN32
+#define WIN32_LEAN_AND_MEAN 1
+#include <windows.h>
+#endif
+
 #include <GL/gl.h>
 
 typedef struct


### PR DESCRIPTION
This is a patch for the error:
error C2054: expected '(' to follow 'WINGDIAPI'
See http://stackoverflow.com/questions/13161391/expected-to-follow-wingdiapi
